### PR TITLE
Add support to print the ANSI RS code separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,26 +115,30 @@ simple steps below.
 # Usage
 
 ### Options
-  | Option              | Function               |
-  | :-----------------: | --------------         |
-  | -b                  | Bold                   |
-  | -u                  | Underline              |
-  | -i                  | Italic                 |
-  | -C `color`          | Specify built in color |
-  | -l                  | List built in colors   |
-  | -n                  | No newline             |
-  | -h                  | Display help page      |
+  | Option              | Function                    |
+  | :-----------------: | --------------              |
+  | -b                  | Bold                        |
+  | -u                  | Underline                   |
+  | -i                  | Italic                      |
+  | -C `color`          | Specify built in color      |
+  | -l                  | List built in colors        |
+  | -n                  | No newline                  |
+  | -r                  | No ending ANSI code         |
+  | -R                  | Print only ending ANSI code |
+  | -h                  | Display help page           |
 
 ### General Structure of Command
- * `printc [-b] [-u] [-i] [-n] <0-255> <0-255> <0-255> "Colorized Text to Display"`
+ * `printc [-b] [-u] [-i] [-n] [-r] <0-255> <0-255> <0-255> "Colorized Text to Display"`
      * This is the structure used when specifying a color with RGB values.
      * Note the absense of quotes around the RGB numbers, this is required.
      * Note the inclusion of quotes around the intended output, also required.
          * As usual double quotes will allow parameter expansion.
      * The RGB values must come after any options, and before the intended output.
- * `printc [-b] [-u] [-i] [-n]> -C <built in color> "Colorized Text to Display"`
+ * `printc [-b] [-u] [-i] [-n] [-r] -C <built in color> "Colorized Text to Display"`
      * This is the structure used when specifying a color that is built in to the plugin.
      * Quoting the intended output is not required when using built in color options.
+ * `printc -R`
+     * For use with an earlier `printc -r -C <color> "text"`, for use in prompts and other places where the color code and the ending code may need to be separate.
  * Options can be given in any order, and chained together, such as
  `-buinC <built in color>`, so long as `built in color` follows immediately after `-C`,
    and in the case of using RGB values, they must come after any options that are given.

--- a/_printc
+++ b/_printc
@@ -10,6 +10,8 @@ _printc() {
     "-l[list built in colors]"
     "-h[show help message]"
     "-n[suppress newline]"
+    "-r[suppress closing ANSI code]"
+    "-R[print only closing ANSI code]"
     "-C[built in colors]:custom:(cayenne \
       mocha asparagus fern clover moss teal \
       ocean midnight eggplant plum maroon maraschino \

--- a/printc
+++ b/printc
@@ -14,6 +14,8 @@ ${yellow}FLAGS:${RS}
     ${green}-i${RS}     \033[3mitalic${RS}
     ${green}-u${RS}     \033[4munderline${RS}
     ${green}-n${RS}     do not add newline to the result${RS}
+    ${green}-r${RS}     do not add ending escape sequence to the result${RS}
+    ${green}-R${RS}     print ONLY the ending escape sequence (assumes -n)${RS}
     ${green}-l${RS}     list built in colors${RS}
     ${green}-h${RS}     show this help message${RS}
 
@@ -112,7 +114,13 @@ test_input() {
 }
 
 zparseopts -D - \
-  C:=color_flag u=u_flag b=b_flag i=i_flag l=l_flag h=h_flag n=n_flag
+  C:=color_flag u=u_flag b=b_flag i=i_flag l=l_flag h=h_flag n=n_flag \
+  r=r_flag R=R_flag
+
+if [[ $R_flag ]]; then
+  echo -n "${RS}"
+  exit 0
+fi
 
 if [[ $l_flag ]] || [[ $h_flag ]];then
   [[ $h_flag ]] && usage || \
@@ -169,6 +177,13 @@ else
     usage
     exit 1
   fi
+fi
+
+if [[ $r_flag ]]; then
+  # If -N option is given, omit the closing escape sequence
+  # maybe a little hackish, but it's the end of the script, so
+  # we're not going to need the correct $RS later
+  RS=''
 fi
 
 if [[ $n_flag ]]; then

--- a/printc
+++ b/printc
@@ -180,7 +180,7 @@ else
 fi
 
 if [[ $r_flag ]]; then
-  # If -N option is given, omit the closing escape sequence
+  # If -r option is given, omit the closing escape sequence
   # maybe a little hackish, but it's the end of the script, so
   # we're not going to need the correct $RS later
   RS=''


### PR DESCRIPTION
I find it useful to be able to split the color code (and text) from the ending closing ANSI escape code `\[[0m`.

This patch creates two additional flags:
- `-r`, to omit the closing ANSI escape code
- `-R`, to print only that code, nothing else