### PR TITLE
Add support for blinking text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ can be achieved via the form R G B, where R, G and B are any numeric value
 between 0 and 255, representing the red, green, blue color space values respectively.
 Users of this plugin are able to issue a  `printc` statement, followed by the previous
 mentioned rgb values, followed by the text to be printed. There is also 36 built in colors
-which can be accessed via tab auto-complete. And there is support for bold, italic, and
-underline text.
+which can be accessed via tab auto-complete. And there is support for bold, italic,
+blinking, and underline text.
 
 ![screenshot](https://imgur.com/K0FVGzr.png)
 
@@ -112,6 +112,11 @@ simple steps below.
  As an aside, I have not tested this inside TMUX, but it should work there as long as the
  environment is set up to properly handle color and italics.
 
+### Blinking Text
+
+Many terminals have no support for blinking text. This may be considered a feature of
+those terminals rather than a bug.
+
 # Usage
 
 ### Options
@@ -120,19 +125,20 @@ simple steps below.
   | -b                  | Bold                   |
   | -u                  | Underline              |
   | -i                  | Italic                 |
+  | -k                  | Blink                  |
   | -C `color`          | Specify built in color |
   | -l                  | List built in colors   |
   | -n                  | No newline             |
   | -h                  | Display help page      |
 
 ### General Structure of Command
- * `printc [-b] [-u] [-i] [-n] <0-255> <0-255> <0-255> "Colorized Text to Display"`
+ * `printc [-b] [-u] [-i] [-k] [-n] <0-255> <0-255> <0-255> "Colorized Text to Display"`
      * This is the structure used when specifying a color with RGB values.
      * Note the absense of quotes around the RGB numbers, this is required.
      * Note the inclusion of quotes around the intended output, also required.
          * As usual double quotes will allow parameter expansion.
      * The RGB values must come after any options, and before the intended output.
- * `printc [-b] [-u] [-i] [-n]> -C <built in color> "Colorized Text to Display"`
+ * `printc [-b] [-u] [-i] [-k] [-n] -C <built in color> "Colorized Text to Display"`
      * This is the structure used when specifying a color that is built in to the plugin.
      * Quoting the intended output is not required when using built in color options.
  * Options can be given in any order, and chained together, such as

--- a/_printc
+++ b/_printc
@@ -7,6 +7,7 @@ _printc() {
     "-b[bold]"
     "-i[italic]"
     "-u[underline]"
+    "-k[blink]"
     "-l[list built in colors]"
     "-h[show help message]"
     "-n[suppress newline]"

--- a/printc
+++ b/printc
@@ -13,6 +13,7 @@ ${yellow}FLAGS:${RS}
     ${green}-b${RS}     \033[1mbold${RS}
     ${green}-i${RS}     \033[3mitalic${RS}
     ${green}-u${RS}     \033[4munderline${RS}
+    ${green}-k${RS}     \033[5mblink${RS}
     ${green}-n${RS}     do not add newline to the result${RS}
     ${green}-l${RS}     list built in colors${RS}
     ${green}-h${RS}     show this help message${RS}
@@ -112,7 +113,8 @@ test_input() {
 }
 
 zparseopts -D - \
-  C:=color_flag u=u_flag b=b_flag i=i_flag l=l_flag h=h_flag n=n_flag
+  C:=color_flag u=u_flag b=b_flag i=i_flag k=k_flag \
+  l=l_flag h=h_flag n=n_flag
 
 if [[ $l_flag ]] || [[ $h_flag ]];then
   [[ $h_flag ]] && usage || \
@@ -122,7 +124,7 @@ if [[ $l_flag ]] || [[ $h_flag ]];then
     }
   exit 0
 elif [[ $color_flag ]] || [[ $u_flag ]] || \
-  [[ $b_flag ]] || [[ $i_flag ]]; then
+  [[ $b_flag ]] || [[ $i_flag ]] || [[ $k_flag ]]; then
 
   if [[ $color_flag ]]; then
     test_input $color_flag[2]
@@ -141,6 +143,9 @@ elif [[ $color_flag ]] || [[ $u_flag ]] || \
   fi
   if [[ $i_flag ]]; then
     IT="\033[3m" # italic
+  fi
+  if [[ $k_flag ]]; then
+    IT="\033[5m" # blink
   fi
 fi
 


### PR DESCRIPTION
This patch creates one additional flag:
- `-k`, to cause the output text to blink